### PR TITLE
feat(metaplex-nft): add support for Metaplex NFT collections 

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,10 +51,10 @@ $ pnpx @fragmetric-labs/snapshot@latest snapshot --rpc '<RPC-URL>' sandglass-yie
 $ pnpx @fragmetric-labs/snapshot@latest snapshot --rpc '<RPC-URL>' sonic-bridge 6frK7w6bRkRTutjmeiTJoD6tcBjrCh9Aph1tfkW35yoW WFRGSWjaz8tbAxsJitmbfRuFV2mSNwy7BMWcCwaA28U
 
 # Topu NFT collection (with reveal/epic logic)
-$ pnpx @fragmetric-labs/snapshot@latest snapshot --rpc '<HELIUS-RPC-URL>' metaplex-nft 6WTgf5Gt3SHuJeHtxsHuniRMdu2kAAVJLYAcG3nTpxj4 metaplexNFT111111111111111111111
+$ pnpx @fragmetric-labs/snapshot@latest snapshot --rpc '<HELIUS-RPC-URL>' metaplex-nft 6WTgf5Gt3SHuJeHtxsHuniRMdu2kAAVJLYAcG3nTpxj4
 
 # General Metaplex NFT collection
-$ pnpx @fragmetric-labs/snapshot@latest snapshot --rpc '<HELIUS-RPC-URL>' metaplex-nft <COLLECTION_ADDRESS> metaplexNFT111111111111111111111
+$ pnpx @fragmetric-labs/snapshot@latest snapshot --rpc '<HELIUS-RPC-URL>' metaplex-nft <COLLECTION_ADDRESS>
 ```
 
 ### How to Contribute

--- a/README.md
+++ b/README.md
@@ -49,6 +49,12 @@ $ pnpx @fragmetric-labs/snapshot@latest snapshot --rpc '<RPC-URL>' texture-lendi
 $ pnpx @fragmetric-labs/snapshot@latest snapshot --rpc '<RPC-URL>' sandglass-yield-trading 8BTZiJ5G8SkB69bPtGfA2eiyYhkqbDhf8ryxovJFVnuJ WFRGSWjaz8tbAxsJitmbfRuFV2mSNwy7BMWcCwaA28U
 
 $ pnpx @fragmetric-labs/snapshot@latest snapshot --rpc '<RPC-URL>' sonic-bridge 6frK7w6bRkRTutjmeiTJoD6tcBjrCh9Aph1tfkW35yoW WFRGSWjaz8tbAxsJitmbfRuFV2mSNwy7BMWcCwaA28U
+
+# Topu NFT collection (with reveal/epic logic)
+$ pnpx @fragmetric-labs/snapshot@latest snapshot --rpc '<HELIUS-RPC-URL>' metaplex-nft 6WTgf5Gt3SHuJeHtxsHuniRMdu2kAAVJLYAcG3nTpxj4 metaplexNFT111111111111111111111
+
+# General Metaplex NFT collection
+$ pnpx @fragmetric-labs/snapshot@latest snapshot --rpc '<HELIUS-RPC-URL>' metaplex-nft <COLLECTION_ADDRESS> metaplexNFT111111111111111111111
 ```
 
 ### How to Contribute
@@ -101,4 +107,9 @@ stdout | src/commands/snapshot/source/banx-looping.test.ts > snapshot source: ba
 ```
 
 `export SOLANA_RPC_MAINNET="https://custom-rpc-url"` to configure RPC for test suites.
-Some snapshot sources require `helius` rpc due to dependencies to specific RPC methods. (e.g. `orca-liqudity` source not works with other RPCs)
+Some snapshot sources require `helius` rpc due to dependencies to specific RPC methods:
+
+- `orca-liquidity` source not works with other RPCs
+- `metaplex-nft` requires Helius RPC for `searchAssets` method
+  - Topu collection (`6WTgf5Gt3SHuJeHtxsHuniRMdu2kAAVJLYAcG3nTpxj4`): applies reveal/epic logic
+  - Other collections: counts all NFTs as normal (baseTokenBalance = NFT count)

--- a/src/commands/snapshot/source/index.ts
+++ b/src/commands/snapshot/source/index.ts
@@ -13,6 +13,7 @@ import { textureLending } from './texture-lending';
 import { loopscaleLending } from './loopscale-lending';
 import { loopscaleLooping } from './loopscale-looping';
 import { sonicBridge } from './sonic-bridge';
+import { metaplexNFT } from './metaplex-nft';
 
 export const sources = {
   'orca-liquidity': orcaLiquidity,
@@ -28,6 +29,7 @@ export const sources = {
   'loopscale-lending': loopscaleLending,
   'loopscale-looping': loopscaleLooping,
   'sonic-bridge': sonicBridge,
+  'metaplex-nft': metaplexNFT,
 };
 
 export type Snapshot = {

--- a/src/commands/snapshot/source/metaplex-nft.test.ts
+++ b/src/commands/snapshot/source/metaplex-nft.test.ts
@@ -1,0 +1,25 @@
+import { describe, test } from 'vitest';
+import { metaplexNFT } from './metaplex-nft';
+import { expectSnapshotSourceWorks } from './testutil';
+
+describe('snapshot source: metaplex-nft', async () => {
+  test('Topu collection snapshot with revealed NFTs only', async () => {
+    await expectSnapshotSourceWorks(metaplexNFT, {
+      source: 'metaplex-nft',
+      args: [
+        '6WTgf5Gt3SHuJeHtxsHuniRMdu2kAAVJLYAcG3nTpxj4', // Topu collection
+        'metaplexNFT111111111111111111111', // virtual receipt token mint
+      ],
+    });
+  });
+
+  test('General Metaplex NFT collection snapshot', async () => {
+    await expectSnapshotSourceWorks(metaplexNFT, {
+      source: 'metaplex-nft',
+      args: [
+        'J1S9H3QjnRtBbbuD4HjPV6RpRhwuk4zKbxsnCHuTgh9w', // Mad Lads collection (example)
+        'metaplexNFT111111111111111111111', // virtual receipt token mint
+      ],
+    });
+  });
+});

--- a/src/commands/snapshot/source/metaplex-nft.test.ts
+++ b/src/commands/snapshot/source/metaplex-nft.test.ts
@@ -8,7 +8,6 @@ describe('snapshot source: metaplex-nft', async () => {
       source: 'metaplex-nft',
       args: [
         '6WTgf5Gt3SHuJeHtxsHuniRMdu2kAAVJLYAcG3nTpxj4', // Topu collection
-        'metaplexNFT111111111111111111111', // virtual receipt token mint
       ],
     });
   });
@@ -18,7 +17,6 @@ describe('snapshot source: metaplex-nft', async () => {
       source: 'metaplex-nft',
       args: [
         'J1S9H3QjnRtBbbuD4HjPV6RpRhwuk4zKbxsnCHuTgh9w', // Mad Lads collection (example)
-        'metaplexNFT111111111111111111111', // virtual receipt token mint
       ],
     });
   });

--- a/src/commands/snapshot/source/metaplex-nft.ts
+++ b/src/commands/snapshot/source/metaplex-nft.ts
@@ -1,0 +1,218 @@
+import { SourceStreamFactory, SourceStreamOptions } from './index';
+import retry from 'promise-retry';
+
+const CONSTANTS = {
+  PAGE_LIMIT: 1000,
+  RETRY_CONFIG: {
+    retries: 5,
+    minTimeout: 500,
+    maxTimeout: 10_000,
+  },
+  VIRTUAL_RECEIPT_TOKEN_MINT_ADDRESS: 'metaplexNFT111111111111111111111',
+
+  // Topu-specific constants
+  TOPU_COLLECTION_ID: '6WTgf5Gt3SHuJeHtxsHuniRMdu2kAAVJLYAcG3nTpxj4',
+  TOPU_REVEALED_JSON_URI_DOMAIN: 'nft-assets.topu.inc',
+  TOPU_UNREVEALED_JSON_URI_DOMAIN:
+    'bafybeiff3it3mcgkjtl5vcm2zni3miutlzrqpxylpgu3jzyqmykxay5gcm.ipfs.w3s.link',
+} as const;
+
+const TOPU_EPIC_TRAITS = [
+  { trait_type: 'Color', value: 'Solana' },
+  { trait_type: 'Type', value: 'Skull' },
+  { trait_type: 'Skin', value: 'Galaxy_male' },
+  { trait_type: 'Skin', value: 'Aurora_female' },
+  { trait_type: 'Eyes', value: 'Insane Mint_male' },
+  { trait_type: 'Eyes', value: 'Insane Yellow_male' },
+  { trait_type: 'Clothing', value: 'TOPU PJ_male' },
+  { trait_type: 'Position', value: 'Medic_short' },
+];
+
+interface SearchAssetsResultItem {
+  id: string;
+  content?: {
+    json_uri?: string;
+    metadata?: {
+      name?: string;
+      attributes?: Array<{
+        trait_type: string;
+        value: string;
+      }>;
+    };
+  };
+  ownership?: {
+    owner?: string;
+  };
+}
+
+interface RpcResponse {
+  result?: {
+    items?: SearchAssetsResultItem[];
+  };
+  error?: {
+    message?: string;
+  };
+}
+
+interface NFTCounts {
+  epic: number;
+  normal: number;
+}
+
+function isTopuCollection(collectionId: string): boolean {
+  return collectionId === CONSTANTS.TOPU_COLLECTION_ID;
+}
+
+function isTopuRevealed(jsonUri: string | undefined): boolean {
+  if (!jsonUri) return false;
+  return jsonUri.includes(CONSTANTS.TOPU_REVEALED_JSON_URI_DOMAIN);
+}
+
+function isTopuEpic(attributes: Array<{ trait_type: string; value: string }> | undefined): boolean {
+  if (!attributes) return false;
+
+  return TOPU_EPIC_TRAITS.some((epicTrait) =>
+    attributes.some(
+      (attr) => attr.trait_type === epicTrait.trait_type && attr.value === epicTrait.value,
+    ),
+  );
+}
+
+function calculateBaseTokenBalance(counts: NFTCounts): number {
+  return counts.epic * 1_000_000 + counts.normal;
+}
+
+function processNFTItem(
+  item: SearchAssetsResultItem,
+  ownerToCounts: Map<string, NFTCounts>,
+  collectionId: string,
+): void {
+  const owner = item.ownership?.owner;
+  if (!owner) return;
+
+  const counts = ownerToCounts.get(owner) || { epic: 0, normal: 0 };
+
+  if (isTopuCollection(collectionId)) {
+    // Topu-specific logic: only process revealed NFTs
+    const jsonUri = item.content?.json_uri;
+    if (!isTopuRevealed(jsonUri)) {
+      return;
+    }
+
+    const attributes = item.content?.metadata?.attributes;
+    const isEpicNFT = isTopuEpic(attributes);
+
+    if (isEpicNFT) {
+      counts.epic += 1;
+    } else {
+      counts.normal += 1;
+    }
+  } else {
+    // General Metaplex NFT logic: count all NFTs as normal
+    counts.normal += 1;
+  }
+
+  ownerToCounts.set(owner, counts);
+}
+
+async function fetchPage(
+  rpc: string,
+  collectionId: string,
+  page: number,
+): Promise<SearchAssetsResultItem[]> {
+  try {
+    const data = await retry(CONSTANTS.RETRY_CONFIG, async () => {
+      const response = await fetch(rpc, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          jsonrpc: '2.0',
+          id: `metaplex-nft.searchAssets.page.${page}`,
+          method: 'searchAssets',
+          params: {
+            grouping: ['collection', collectionId],
+            page,
+            limit: CONSTANTS.PAGE_LIMIT,
+          },
+        }),
+      });
+
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+      }
+
+      const body: RpcResponse = await response.json();
+      if (body.error) {
+        throw new Error(`RPC Error: ${body.error.message || 'Unknown error'}`);
+      }
+
+      return body.result || { items: [] };
+    });
+
+    return data.items || [];
+  } catch (error) {
+    throw new Error(`Failed to fetch page ${page}: ${(error as Error).message}`);
+  }
+}
+
+async function collectNFTData(rpc: string, collectionId: string): Promise<Map<string, NFTCounts>> {
+  const ownerToCounts = new Map<string, NFTCounts>();
+  let page = 1;
+
+  while (true) {
+    const items = await fetchPage(rpc, collectionId, page);
+
+    for (const item of items) {
+      processNFTItem(item, ownerToCounts, collectionId);
+    }
+
+    if (items.length < CONSTANTS.PAGE_LIMIT) {
+      break;
+    }
+
+    page += 1;
+  }
+
+  return ownerToCounts;
+}
+
+function generateSnapshots(ownerToCounts: Map<string, NFTCounts>, opts: SourceStreamOptions): void {
+  let totalBaseTokenBalance = 0n;
+  let epicOwners = 0;
+  let normalOnlyOwners = 0;
+
+  for (const [owner, counts] of ownerToCounts.entries()) {
+    const baseTokenBalance = calculateBaseTokenBalance(counts);
+    totalBaseTokenBalance += BigInt(baseTokenBalance);
+
+    if (counts.epic > 0) {
+      epicOwners++;
+    } else {
+      normalOnlyOwners++;
+    }
+
+    opts.produceSnapshot({ owner, baseTokenBalance });
+  }
+}
+
+export const metaplexNFT: SourceStreamFactory = async (opts) => {
+  const collectionId = opts.args[0];
+  const receiptTokenMint = opts.args[1]; // "metaplexNFT111111111111111111111"
+
+  if (!collectionId) {
+    throw new Error('Collection ID is required as first argument');
+  }
+
+  if (!receiptTokenMint || receiptTokenMint !== CONSTANTS.VIRTUAL_RECEIPT_TOKEN_MINT_ADDRESS) {
+    throw new Error(`Receipt token mint must be "${CONSTANTS.VIRTUAL_RECEIPT_TOKEN_MINT_ADDRESS}"`);
+  }
+
+  try {
+    const ownerToCounts = await collectNFTData(opts.rpc, collectionId);
+    generateSnapshots(ownerToCounts, opts);
+    opts.close();
+  } catch (error) {
+    console.error(`[METAPLEX-NFT] Error:`, error);
+    opts.close(error as Error);
+  }
+};


### PR DESCRIPTION
### metaplex-nft source with topu-specific reveal/epic logic and general collection support
- Add metaplex-nft snapshot source: general Metaplex support, with topu-specific reveal/EPIC trait logic for the topu collection.
- Register source, add tests (topu + general), and update README with usage and Helius RPC (searchAssets) requirement.
- Emit {owner, baseTokenBalance} where balance = epic1_000_000 + normal in topu
- validate the virtual receipt token mint.

### result of topu snapshot 
<img width="399" height="111" alt="스크린샷 2025-08-20 18 25 49" src="https://github.com/user-attachments/assets/c6c17a43-0b04-462a-93ac-03db24f0cd46" />

- epic: 253
- normal: 5971
- snapshotCount (unique owners): 2016