### PR TITLE
fix: update topu_epic_tratis to match actual NFT data

### DIFF
--- a/src/commands/snapshot/source/metaplex-nft.ts
+++ b/src/commands/snapshot/source/metaplex-nft.ts
@@ -18,12 +18,12 @@ const CONSTANTS = {
 const TOPU_EPIC_TRAITS = [
   { trait_type: 'Color', value: 'Solana' },
   { trait_type: 'Type', value: 'Skull' },
-  { trait_type: 'Skin', value: 'Galaxy_male' },
-  { trait_type: 'Skin', value: 'Aurora_female' },
-  { trait_type: 'Eyes', value: 'Insane Mint_male' },
-  { trait_type: 'Eyes', value: 'Insane Yellow_male' },
-  { trait_type: 'Clothing', value: 'TOPU PJ_male' },
-  { trait_type: 'Position', value: 'Medic_short' },
+  { trait_type: 'Skin', value: 'Galaxy' },
+  { trait_type: 'Skin', value: 'Aurora' },
+  { trait_type: 'Eyes', value: 'Insane Mint' },
+  { trait_type: 'Eyes', value: 'Insane Yellow' },
+  { trait_type: 'Clothing', value: 'TOPU PJ' },
+  { trait_type: 'Position', value: 'Medic' },
 ];
 
 const TOPU_EPIC_TRAITS_SET = new Set(


### PR DESCRIPTION
- Update TOPU_EPIC_TRAITS to match actual NFT data

before
<img width="570" height="28" alt="스크린샷 2025-09-16 오후 4 55 24" src="https://github.com/user-attachments/assets/962daf74-8b09-4030-8c40-3fdedb25739d" />

after
<img width="552" height="25" alt="스크린샷 2025-09-16 오후 4 56 14" src="https://github.com/user-attachments/assets/525d7a13-8264-4ce9-becd-7b88ffd09677" />

